### PR TITLE
removed condition for checking if config "authorizenettestmode" is TRUE

### DIFF
--- a/libraries/AuthorizeCimLib.php
+++ b/libraries/AuthorizeCimLib.php
@@ -47,8 +47,7 @@ class AuthorizeCimLib
 		$this->_CI->config->load('authorizenet');
 		
 		if($this->_CI->config->item('authorizenetname') && 
-				$this->_CI->config->item('authorizenetkey') &&
-				$this->_CI->config->item('authorizenettestmode'))
+				$this->_CI->config->item('authorizenetkey'))
 		{
 			$this->initialize($this->_CI->config->item('authorizenetname'), 
 												$this->_CI->config->item('authorizenetkey'), 


### PR DESCRIPTION
If it is set to FALSE, then we are in "Production" mode. However, if it's set to FALSE, then it never passes the if() statement and never initializes.
