### PR TITLE
fix duplicate transaction

### DIFF
--- a/libraries/AuthorizeCimLib.php
+++ b/libraries/AuthorizeCimLib.php
@@ -733,7 +733,7 @@ class AuthorizeCimLib
 		$this->_response = curl_exec($ch);
 		
 		// If there was an error. 
-		if(curl_exec($ch) === false)
+		if($this->_response === false)
 		{
 			$this->_success = FALSE;
 			$this->_error = TRUE;


### PR DESCRIPTION
$ch is unnecessarily passed through curl_exec() twice, should be checking the response from the previous curl_exec call instead.

Had a problem with this back when Authorize.NET changed their network to use Akamai and they started leaking duplicate transactions through their network if they were coming fast enough, and these are back-to-back calls so they pretty much are. Doing another update to this codebase and realized I didn't say much at the time - very sorry about that! Should have pushed this back beginning of 2016!

Anyway, I realize this may kind of be a dead project (need updates to support 3.x just for the naming), but it was much appreciated and we were able to use it as a quick patch and to build on when our project got switched to using Auth.NET CIM at the very last minute. Thank you!!